### PR TITLE
Make players an empty array rather than null or undefined.

### DIFF
--- a/src/db/postgres.ts
+++ b/src/db/postgres.ts
@@ -146,7 +146,7 @@ export class PostgresStore extends Async {
     if (metadata) {
       result.metadata = {
         gameName: game.gameName,
-        players: game.players,
+        players: game.players || [],
         setupData: game.setupData,
         gameover: game.gameover,
         nextRoomID: game.nextRoomID,


### PR DESCRIPTION
Using the basic tutorial for remote multiplayer (no lobby or authentication) at https://boardgame.io/documentation/#/multiplayer?id=remote-master get this error:

(node:80710) UnhandledPromiseRejectionWarning: TypeError: Cannot convert undefined or null to object
    at Function.values (<anonymous>)
    at Master.onSync (boardgame.io/dist/cjs/server.js:2877:39)
    at async Socket.<anonymous> (boardgame.io/dist/cjs/server.js:3010:21)
(node:80710) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). To terminate the node process on unhandled promise rejection, use the CLI flag `--unhandled-rejections=strict` (see https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode). (rejection id: 1)
(node:80710) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
^C

It works with the in-memory storage but switching to postgres triggers this error. Very small change to ensure players is an array.