### PR TITLE
Allow Sequelize options to be passed in after URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 You can use the `PostgresStore` in two ways.
-Either provide credentials using a URI as only argument, or by using an options object.
+Either provide credentials using a URI as the first argument, or by using an options object.
 
 ```typescript
 import { Server } from "boardgame.io/server";
@@ -25,3 +25,34 @@ const server = Server({
   db,
 });
 ```
+
+## Optional Parameters
+
+This adapter uses [Sequelize][sequelize] as the ORM. Any additional options provided to `PostgresStore` will be passed to the initialization arguments of the underlying Sequelize instance.
+
+```typescript
+// EITHER provide options after the URI...
+const db = new PostgresStore(
+  "postgresql://<username>:<password>@<host>/<database>",
+  {
+    logging: myLogger,
+    timezone: '+00:00',
+  }
+);
+
+// ...OR provide addition options with the credentials.
+const db = new PostgresStore({
+  database: "database",
+  username: "username",
+  password: "password",
+  host: "host",
+  logging: myLogger,
+  timezone: '+00:00',
+});
+
+```
+
+The full list of available options is documented in the [Sequelize API Docs][class-sequelize].
+
+[sequelize]: https://sequelize.org/master/
+[class-sequelize]: https://sequelize.readthedocs.io/en/latest/api/sequelize/#class-sequelize

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bgio-postgres",
-  "version": "1.0.4",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "build": "tsc",
-    "prepare" : "npm run build",
+    "prepare": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "files": [

--- a/src/db/postgres.ts
+++ b/src/db/postgres.ts
@@ -6,10 +6,10 @@ import { Game, gameAttributes } from "./entities/game";
 export class PostgresStore extends Async {
   private sequelize: Sequelize;
 
-  constructor(uriOrOptions: Options | string) {
+  constructor(uriOrOptions: Options | string, extraOptions?: Options) {
     super();
     if (typeof uriOrOptions === "string") {
-      this.sequelize = new Sequelize(uriOrOptions);
+      this.sequelize = new Sequelize(uriOrOptions, extraOptions);
     } else {
       this.sequelize = new Sequelize({ dialect: "postgres", ...uriOrOptions });
     }

--- a/src/db/postgres.ts
+++ b/src/db/postgres.ts
@@ -11,7 +11,7 @@ export class PostgresStore extends Async {
   constructor(uriOrOptions: Options | string, extraOptions?: Options) {
     super();
     if (typeof uriOrOptions === "string") {
-      this.sequelize = new Sequelize(uriOrOptions, extraOptions);
+      this.sequelize = new Sequelize(uriOrOptions, extraOptions || {});
     } else {
       this.sequelize = new Sequelize({ dialect: "postgres", ...uriOrOptions });
     }

--- a/src/db/postgres.ts
+++ b/src/db/postgres.ts
@@ -6,6 +6,8 @@ import { Game, gameAttributes } from "./entities/game";
 export class PostgresStore extends Async {
   private sequelize: Sequelize;
 
+  constructor(uri: string, options?: Options);
+  constructor(options: Options);
   constructor(uriOrOptions: Options | string, extraOptions?: Options) {
     super();
     if (typeof uriOrOptions === "string") {


### PR DESCRIPTION
## Why

I'd like to be able to customise the logging of database requests in my Boardgame App. Sequelize supports this with the `logging` option at initialization, but I can't pass that option in with the current implementation, as I need to provide a URI instead of an options object. (My cloud hosting provider gives my app a full database URI in the environment variables rather than individual database host/name/password credentials.)

## Alternatives considered
- **Split up the database URI in my app instead of modifying the library.** I don't think this is wise: the database URI provided by the hosting environment should be considered opaque to the app.
- **Add a logging API to this library.** This is a more conservative change, but it feels like reinventing the wheel when Sequelize already has an API for it.
- **Only pass through allow-listed properties to the Sequelize class.** This is safer, but would require this library to have more knowledge of Sequelize, and could frustrate users of this library by not exposing one of the more obscure options that they needed, such as pooling, retrying, timezone-setting, etc.
- **Nest extra Sequelize options under `sequelizeOptions`.** This would prevent potential clashes between Sequelize options and any future potential Game-related options. That seems unlikely, though. Also, it's redundant for the existing PostgresStore options API, as those options are already being passed through to Sequelize.

## Consequences

This is now exposing Sequelize to the API when it was an internal detail of the library before. I think this makes sense because this library is essentially an opinionated wrapper around Sequelize with a pre-set Game model, and Sequelize is a well-tested and well-documented library.